### PR TITLE
feat(NpmBundleSizeBadge): add new NpmBundleSizeBadge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![devDependency status](https://david-dm.org/dbartholomae/jsx-readme/dev-status.svg)](https://david-dm.org/dbartholomae/jsx-readme?type=dev)
 [![semantic release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release#badge)
 [![jsx-readme](https://img.shields.io/badge/jsx--readme-lightgrey)](https://dbartholomae.github.io/jsx-readme)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/jsx-readme.svg)](https://bundlephobia.com/result?p=jsx-readme)
 [![codecov](https://codecov.io/gh/dbartholomae/jsx-readme/branch/main/graph/badge.svg)](https://codecov.io/gh/dbartholomae/jsx-readme)
 [![build status](https://github.com/dbartholomae/jsx-readme/workflows/Build%20and%20deploy/badge.svg?branch=main)](https://github.com/dbartholomae/jsx-readme/actions?query=workflow%3A"Build%20and%20deploy")
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![npm package](https://badge.fury.io/js/jsx-readme.svg)](https://npmjs.org/package/jsx-readme)
 [![downloads](https://img.shields.io/npm/dw/jsx-readme.svg)](https://npm-stat.com/charts.html?package=jsx-readme)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/jsx-readme.svg)](https://bundlephobia.com/result?p=jsx-readme)
 [![open issues](https://img.shields.io/github/issues-raw/dbartholomae/jsx-readme.svg)](https://github.com/dbartholomae/jsx-readme/issues)
 [![dependency status](https://david-dm.org/dbartholomae/jsx-readme.svg?theme=shields.io)](https://david-dm.org/dbartholomae/jsx-readme)
 [![devDependency status](https://david-dm.org/dbartholomae/jsx-readme/dev-status.svg)](https://david-dm.org/dbartholomae/jsx-readme?type=dev)
 [![semantic release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release#badge)
 [![jsx-readme](https://img.shields.io/badge/jsx--readme-lightgrey)](https://dbartholomae.github.io/jsx-readme)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/jsx-readme.svg)](https://bundlephobia.com/result?p=jsx-readme)
 [![codecov](https://codecov.io/gh/dbartholomae/jsx-readme/branch/main/graph/badge.svg)](https://codecov.io/gh/dbartholomae/jsx-readme)
 [![build status](https://github.com/dbartholomae/jsx-readme/workflows/Build%20and%20deploy/badge.svg?branch=main)](https://github.com/dbartholomae/jsx-readme/actions?query=workflow%3A"Build%20and%20deploy")
 

--- a/src/components/BadgesFromPkg.tsx
+++ b/src/components/BadgesFromPkg.tsx
@@ -8,9 +8,9 @@ import {
   GithubIssuesBadge,
   JsxReadmeBadge,
   NpmDownloadsBadge,
+  NpmBundleSizeBadge,
   NpmVersionBadge,
   SemanticReleaseBadge,
-  NpmBundleSizeBadge,
 } from "./badges";
 
 /** @internal */
@@ -23,26 +23,27 @@ interface Props {
 export const badgeComponents = {
   npmVersion: NpmVersionBadge,
   npmDownloads: NpmDownloadsBadge,
+  npmBundleSize: NpmBundleSizeBadge,
   dependenciesBadge: DependenciesBadge,
   devDependenciesBadge: DevDependenciesBadge,
   githubIssues: GithubIssuesBadge,
   jsxReadme: JsxReadmeBadge,
   semanticRelease: SemanticReleaseBadge,
-  npmBundleSize: NpmBundleSizeBadge,
 } as const;
 
 type BadgeName = keyof typeof badgeComponents;
 
 /** @internal */
+/* This array's order determines the order in which components are displayed */
 export const defaultBadges: ReadonlyArray<BadgeName> = [
   "npmVersion",
   "npmDownloads",
+  "npmBundleSize",
   "githubIssues",
   "dependenciesBadge",
   "devDependenciesBadge",
   "semanticRelease",
   "jsxReadme",
-  "npmBundleSize",
 ] as const;
 
 /** Renders a list of badges that can be inferred from `package.json`. */

--- a/src/components/BadgesFromPkg.tsx
+++ b/src/components/BadgesFromPkg.tsx
@@ -10,6 +10,7 @@ import {
   NpmDownloadsBadge,
   NpmVersionBadge,
   SemanticReleaseBadge,
+  NpmBundleSizeBadge,
 } from "./badges";
 
 /** @internal */
@@ -27,6 +28,7 @@ export const badgeComponents = {
   githubIssues: GithubIssuesBadge,
   jsxReadme: JsxReadmeBadge,
   semanticRelease: SemanticReleaseBadge,
+  npmBundleSize: NpmBundleSizeBadge,
 } as const;
 
 type BadgeName = keyof typeof badgeComponents;
@@ -40,6 +42,7 @@ export const defaultBadges: ReadonlyArray<BadgeName> = [
   "devDependenciesBadge",
   "semanticRelease",
   "jsxReadme",
+  "npmBundleSize",
 ] as const;
 
 /** Renders a list of badges that can be inferred from `package.json`. */

--- a/src/components/badges/NpmBundleSizeBadge.test.tsx
+++ b/src/components/badges/NpmBundleSizeBadge.test.tsx
@@ -1,0 +1,31 @@
+/* @jsx MD */
+import MD, { render } from "jsx-md";
+import { Badge } from "../Badge";
+import { NpmBundleSizeBadge } from "./NpmBundleSizeBadge";
+
+describe("NpmBundleSize", () => {
+  it("shows an npm bundle size badge", () => {
+    const pkg = {
+      name: "package-name",
+    };
+
+    expect(render(<NpmBundleSizeBadge pkg={pkg} />)).toContain(
+      render(
+        <Badge
+          imageSource="https://img.shields.io/bundlephobia/minzip/package-name.svg"
+          link="https://bundlephobia.com/result?p=package-name"
+        >
+          bundle size
+        </Badge>
+      )
+    );
+  });
+
+  it("does not show an npm bundle size badge if the package is private", () => {
+    const pkg = {
+      name: "package-name",
+      private: true,
+    };
+    expect(render(<NpmBundleSizeBadge pkg={pkg} />)).toBe("");
+  });
+});

--- a/src/components/badges/NpmBundleSizeBadge.tsx
+++ b/src/components/badges/NpmBundleSizeBadge.tsx
@@ -1,0 +1,19 @@
+/* @jsx MD */
+import MD from "jsx-md";
+import { Badge } from "../Badge";
+import type { BadgeComponent } from "./utils/BadgeComponent";
+
+/** Display a badge with the most recent version of this package on npm. */
+export const NpmBundleSizeBadge: BadgeComponent = ({ pkg }) => {
+  if (pkg.private !== undefined && pkg.private) {
+    return null;
+  }
+  return (
+    <Badge
+      link={`https://bundlephobia.com/result?p=${pkg.name}`}
+      imageSource={`https://img.shields.io/bundlephobia/minzip/${pkg.name}.svg`}
+    >
+      bundle size
+    </Badge>
+  );
+};

--- a/src/components/badges/index.ts
+++ b/src/components/badges/index.ts
@@ -13,3 +13,4 @@ export { CodecovBadge } from "./CodecovBadge";
 export { SemanticReleaseBadge } from "./SemanticReleaseBadge";
 export { DependenciesBadge } from "./DependenciesBadge";
 export { DevDependenciesBadge } from "./DevDependenciesBadge";
+export { NpmBundleSizeBadge } from "./NpmBundleSizeBadge";

--- a/test/README.expected.md
+++ b/test/README.expected.md
@@ -7,6 +7,7 @@
 [![devDependency status](https://david-dm.org/dbartholomae/jsx-readme/dev-status.svg)](https://david-dm.org/dbartholomae/jsx-readme?type=dev)
 [![semantic release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release#badge)
 [![jsx-readme](https://img.shields.io/badge/jsx--readme-lightgrey)](https://dbartholomae.github.io/jsx-readme)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/jsx-readme.svg)](https://bundlephobia.com/result?p=jsx-readme)
 [![codecov](https://codecov.io/gh/dbartholomae/jsx-readme/branch/main/graph/badge.svg)](https://codecov.io/gh/dbartholomae/jsx-readme)
 [![build status](https://github.com/dbartholomae/jsx-readme/workflows/Build%20and%20deploy/badge.svg?branch=main)](https://github.com/dbartholomae/jsx-readme/actions?query=workflow%3A"Build%20and%20deploy")
 

--- a/test/README.expected.md
+++ b/test/README.expected.md
@@ -2,12 +2,12 @@
 
 [![npm package](https://badge.fury.io/js/jsx-readme.svg)](https://npmjs.org/package/jsx-readme)
 [![downloads](https://img.shields.io/npm/dw/jsx-readme.svg)](https://npm-stat.com/charts.html?package=jsx-readme)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/jsx-readme.svg)](https://bundlephobia.com/result?p=jsx-readme)
 [![open issues](https://img.shields.io/github/issues-raw/dbartholomae/jsx-readme.svg)](https://github.com/dbartholomae/jsx-readme/issues)
 [![dependency status](https://david-dm.org/dbartholomae/jsx-readme.svg?theme=shields.io)](https://david-dm.org/dbartholomae/jsx-readme)
 [![devDependency status](https://david-dm.org/dbartholomae/jsx-readme/dev-status.svg)](https://david-dm.org/dbartholomae/jsx-readme?type=dev)
 [![semantic release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release#badge)
 [![jsx-readme](https://img.shields.io/badge/jsx--readme-lightgrey)](https://dbartholomae.github.io/jsx-readme)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/jsx-readme.svg)](https://bundlephobia.com/result?p=jsx-readme)
 [![codecov](https://codecov.io/gh/dbartholomae/jsx-readme/branch/main/graph/badge.svg)](https://codecov.io/gh/dbartholomae/jsx-readme)
 [![build status](https://github.com/dbartholomae/jsx-readme/workflows/Build%20and%20deploy/badge.svg?branch=main)](https://github.com/dbartholomae/jsx-readme/actions?query=workflow%3A"Build%20and%20deploy")
 


### PR DESCRIPTION
This commit thus adds a new badge which uses Bundlephobia to tell
how many KB (or even MB) you will be adding with a new dependency.

This new badge is accessible as `<NpmBundleSizeBadge pkg={pkg} />`.

This pull request solves #8.