### PR TITLE
#4 feat(GithubTopLanguageBadge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![open issues](https://img.shields.io/github/issues-raw/dbartholomae/jsx-readme.svg)](https://github.com/dbartholomae/jsx-readme/issues)
 [![dependency status](https://david-dm.org/dbartholomae/jsx-readme.svg?theme=shields.io)](https://david-dm.org/dbartholomae/jsx-readme)
 [![devDependency status](https://david-dm.org/dbartholomae/jsx-readme/dev-status.svg)](https://david-dm.org/dbartholomae/jsx-readme?type=dev)
+[![GitHub Top language](https://img.shields.io/github/languages/top/dbartholomae/jsx-readme)](https://github.com/dbartholomae/jsx-readme)
 [![semantic release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release#badge)
 [![jsx-readme](https://img.shields.io/badge/jsx--readme-lightgrey)](https://dbartholomae.github.io/jsx-readme)
 [![codecov](https://codecov.io/gh/dbartholomae/jsx-readme/branch/main/graph/badge.svg)](https://codecov.io/gh/dbartholomae/jsx-readme)

--- a/src/components/BadgesFromPkg.tsx
+++ b/src/components/BadgesFromPkg.tsx
@@ -5,6 +5,7 @@ import type { PackageJSON } from "../PackageJSON";
 import {
   DependenciesBadge,
   DevDependenciesBadge,
+  GithubTopLanguageBadge,
   GithubIssuesBadge,
   JsxReadmeBadge,
   NpmDownloadsBadge,
@@ -26,6 +27,7 @@ export const badgeComponents = {
   npmBundleSize: NpmBundleSizeBadge,
   dependenciesBadge: DependenciesBadge,
   devDependenciesBadge: DevDependenciesBadge,
+  githubTopLanguageBadge: GithubTopLanguageBadge,
   githubIssues: GithubIssuesBadge,
   jsxReadme: JsxReadmeBadge,
   semanticRelease: SemanticReleaseBadge,
@@ -42,6 +44,7 @@ export const defaultBadges: ReadonlyArray<BadgeName> = [
   "githubIssues",
   "dependenciesBadge",
   "devDependenciesBadge",
+  "githubTopLanguageBadge",
   "semanticRelease",
   "jsxReadme",
 ] as const;

--- a/src/components/badges/GithubTopLanguageBadge.test.tsx
+++ b/src/components/badges/GithubTopLanguageBadge.test.tsx
@@ -1,0 +1,41 @@
+/* @jsx MD */
+import MD, { render } from "jsx-md";
+import { Badge } from "../Badge";
+import { GithubTopLanguageBadge } from "./GithubTopLanguageBadge";
+
+describe("GithubTopLanguageBadge", () => {
+  it("shows a github-top-language badge if repository is in npm shortform", () => {
+    const pkg = {
+      name: "package-name",
+      repository: "github:dbartholomae/jsx-readme",
+    };
+
+    expect(render(<GithubTopLanguageBadge pkg={pkg} />)).toContain(
+      render(
+        <Badge
+          imageSource="https://img.shields.io/github/languages/top/dbartholomae/jsx-readme"
+          link="https://github.com/dbartholomae/jsx-readme"
+        >
+          GitHub Top language
+        </Badge>
+      )
+    );
+  });
+
+  it("shows nothing if there is no repository", () => {
+    const pkg = {
+      name: "package-name",
+    };
+
+    expect(render(<GithubTopLanguageBadge pkg={pkg} />)).toBe("");
+  });
+
+  it("shows nothing if the repository is a bitbucket repo", () => {
+    const pkg = {
+      name: "package-name",
+      repository: "bitbucket:user/repo",
+    };
+
+    expect(render(<GithubTopLanguageBadge pkg={pkg} />)).toBe("");
+  });
+});

--- a/src/components/badges/GithubTopLanguageBadge.tsx
+++ b/src/components/badges/GithubTopLanguageBadge.tsx
@@ -1,0 +1,22 @@
+/* @jsx MD */
+import MD from "jsx-md";
+import { Badge } from "../Badge";
+import { extractGithubOwnerAndRepo } from "./utils/extractGithubOwnerAndRepo";
+import type { BadgeComponent } from "./utils/BadgeComponent";
+
+/** Display a badge with the top language used for a GitHub repository */
+export const GithubTopLanguageBadge: BadgeComponent = ({ pkg }) => {
+  const ownerAndRepo = extractGithubOwnerAndRepo(pkg.repository);
+  if (ownerAndRepo === undefined) {
+    return null;
+  }
+  const { owner, repo } = ownerAndRepo;
+  return (
+    <Badge
+      link={`https://github.com/${owner}/${repo}`}
+      imageSource={`https://img.shields.io/github/languages/top/${owner}/${repo}`}
+    >
+      GitHub Top language
+    </Badge>
+  );
+};

--- a/src/components/badges/index.ts
+++ b/src/components/badges/index.ts
@@ -8,6 +8,7 @@ export { GithubIssuesBadge } from "./GithubIssuesBadge";
 export { JsxReadmeBadge } from "./JsxReadmeBadge";
 export { NpmVersionBadge } from "./NpmVersionBadge";
 export { NpmDownloadsBadge } from "./NpmDownloadsBadge";
+export { GithubTopLanguageBadge } from "./GithubTopLanguageBadge";
 export { GithubWorkflowBadge } from "./GithubWorkflowBadge";
 export { CodecovBadge } from "./CodecovBadge";
 export { SemanticReleaseBadge } from "./SemanticReleaseBadge";

--- a/test/README.expected.md
+++ b/test/README.expected.md
@@ -6,6 +6,7 @@
 [![open issues](https://img.shields.io/github/issues-raw/dbartholomae/jsx-readme.svg)](https://github.com/dbartholomae/jsx-readme/issues)
 [![dependency status](https://david-dm.org/dbartholomae/jsx-readme.svg?theme=shields.io)](https://david-dm.org/dbartholomae/jsx-readme)
 [![devDependency status](https://david-dm.org/dbartholomae/jsx-readme/dev-status.svg)](https://david-dm.org/dbartholomae/jsx-readme?type=dev)
+[![GitHub Top language](https://img.shields.io/github/languages/top/dbartholomae/jsx-readme)](https://github.com/dbartholomae/jsx-readme)
 [![semantic release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release#badge)
 [![jsx-readme](https://img.shields.io/badge/jsx--readme-lightgrey)](https://dbartholomae.github.io/jsx-readme)
 [![codecov](https://codecov.io/gh/dbartholomae/jsx-readme/branch/main/graph/badge.svg)](https://codecov.io/gh/dbartholomae/jsx-readme)


### PR DESCRIPTION
### Added

- `GithubTopLanguageBadge` which display a badge with the top language used for a GitHub repository.

### Changed

- `BadgesFromPkg` to include `GithubTopLanguageBadge` by default.
- End to end tests which includes `GithubTopLanguageBadge`.