### PR TITLE
feat(LicenseBadge): add badge and tests

### DIFF
--- a/src/components/badges/LicenseBadge.test.tsx
+++ b/src/components/badges/LicenseBadge.test.tsx
@@ -1,0 +1,83 @@
+/* @jsx MD */
+import MD, { render } from "jsx-md";
+import { Badge } from "../Badge";
+import { LicenseBadge } from "./LicenseBadge";
+
+describe("LicenseBadge", () => {
+  it("shows a license badge if repository is in npm shortform", () => {
+    const pkg = {
+      name: "package-name",
+      repository: "github:dbartholomae/jsx-readme",
+    };
+
+    expect(render(<LicenseBadge pkg={pkg} />)).toContain(
+      render(
+        <Badge
+          imageSource="https://img.shields.io/github/license/dbartholomae/jsx-readme"
+          link="https://github.com/dbartholomae/jsx-readme/blob/main/LICENSE"
+        >
+          license
+        </Badge>
+      )
+    );
+  });
+
+  it("shows a license badge with a non-default branch", () => {
+    const pkg = {
+      name: "package-name",
+      repository: "github:dbartholomae/jsx-readme",
+    };
+
+    const branch = "master";
+
+    expect(render(<LicenseBadge pkg={pkg} branch={branch} />)).toContain(
+      render(
+        <Badge
+          imageSource="https://img.shields.io/github/license/dbartholomae/jsx-readme"
+          link="https://github.com/dbartholomae/jsx-readme/blob/master/LICENSE"
+        >
+          license
+        </Badge>
+      )
+    );
+  });
+
+  it("shows a license badge with a non-default license filename", () => {
+    const pkg = {
+      name: "package-name",
+      repository: "github:dbartholomae/jsx-readme",
+    };
+
+    const licenseFileName = "LICENSE.txt";
+
+    expect(
+      render(<LicenseBadge pkg={pkg} licenseFileName={licenseFileName} />)
+    ).toContain(
+      render(
+        <Badge
+          imageSource="https://img.shields.io/github/license/dbartholomae/jsx-readme"
+          link="https://github.com/dbartholomae/jsx-readme/blob/main/LICENSE.txt"
+        >
+          license
+        </Badge>
+      )
+    );
+  });
+
+  it("shows nothing if there is no repository", () => {
+    const pkg = {
+      name: "package-name",
+    };
+
+    expect(render(<LicenseBadge pkg={pkg} />)).toBe("");
+  });
+
+  it("shows nothing if the repository is a bitbucket repo", () => {
+    const pkg = {
+      name: "package-name",
+      repository: "bitbucket:user/repo",
+    };
+
+    expect(render(<LicenseBadge pkg={pkg} />)).toBe("");
+  });
+});

--- a/src/components/badges/LicenseBadge.tsx
+++ b/src/components/badges/LicenseBadge.tsx
@@ -1,0 +1,33 @@
+/* @jsx MD */
+import MD, { Component } from "jsx-md";
+import { Badge } from "../Badge";
+import { extractGithubOwnerAndRepo } from "./utils/extractGithubOwnerAndRepo";
+import { PackageJSON } from "../../PackageJSON";
+
+/** @internal */
+interface Props {
+  branch?: string;
+  licenseFileName?: string;
+  pkg: Readonly<PackageJSON>;
+}
+
+/** Display a badge with the license used for a GitHub repository */
+export const LicenseBadge: Component<Props> = ({
+  pkg,
+  branch = "main",
+  licenseFileName = "LICENSE",
+}) => {
+  const ownerAndRepo = extractGithubOwnerAndRepo(pkg.repository);
+  if (ownerAndRepo === undefined) {
+    return null;
+  }
+  const { owner, repo } = ownerAndRepo;
+  return (
+    <Badge
+      link={`https://github.com/${owner}/${repo}/blob/${branch}/${licenseFileName}`}
+      imageSource={`https://img.shields.io/github/license/${owner}/${repo}`}
+    >
+      license
+    </Badge>
+  );
+};

--- a/src/components/badges/index.ts
+++ b/src/components/badges/index.ts
@@ -6,6 +6,7 @@
  */
 export { GithubIssuesBadge } from "./GithubIssuesBadge";
 export { JsxReadmeBadge } from "./JsxReadmeBadge";
+export { LicenseBadge } from "./LicenseBadge";
 export { NpmVersionBadge } from "./NpmVersionBadge";
 export { NpmDownloadsBadge } from "./NpmDownloadsBadge";
 export { GithubTopLanguageBadge } from "./GithubTopLanguageBadge";


### PR DESCRIPTION
Closes #19 

## Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.

---

As mentioned in #19 on my thoughts on the API implementation for `LicenseBadge`, I've decided to simplify the component and let the Shield.io to do the heavy lifting. Let me know what do you think.