### PR TITLE
Initialization script to create README.md.tsx file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Generate Readme files with a React-like syntax and package.json-aware helpers.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "bin": {
+    "jsx-readme": "lib/cli.js"
+  },
   "scripts": {
     "build": "rimraf lib && tsc -p tsconfig.build.json",
     "docs": "typedoc && touch docs/.nojekyll && ts-node examples/README.md.tsx",
@@ -36,7 +39,13 @@
     "example": "examples"
   },
   "dependencies": {
-    "jsx-md": "^1.2.0"
+    "chalk": "^4.1.0",
+    "clear": "^0.1.0",
+    "commander": "^6.1.0",
+    "figlet": "^1.5.0",
+    "fs-extra": "^9.0.1",
+    "jsx-md": "^1.2.0",
+    "path": "^0.12.7"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
@@ -57,6 +66,7 @@
     "jest": "^26.4.2",
     "lint-staged": "^10.2.13",
     "mock-fs": "^4.13.0",
+    "nodemon": "^2.0.4",
     "pkg-ok": "^2.3.1",
     "prettier": "^2.1.0",
     "rimraf": "^3.0.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+import * as fs from 'fs';
+
+/**
+ * This is the tiny CLI for jsx-readme
+ * it has two functions Start() that activates the CLI when called with the handle 'jsx-readme'
+ * and CreateReadmeJsx() creates the actual README.md.tsx file
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+const _require = require(`child_process`),
+  execSync = _require.execSync;
+/* eslint-enable @typescript-eslint/naming-convention */
+export default class Cli {
+  private clear: any = require('clear');
+  private figlet: any = require('figlet');
+  private path: any = require('path');
+  private chalk: any = require('chalk');
+  private commander: any = require('commander')
+  private pjson: any = require('../package.json');
+  constructor() {
+  }
+  public async Start(): Promise<Boolean> {
+    this.clear();
+    console.log(
+      this.chalk.red(
+        this.figlet.textSync('jsx-readme', { horizontalLayout: 'full' })
+      )
+    );
+    this.commander
+      .version(this.pjson.version)
+      .name('jsx-readme')
+      .description("Generate Readme files with a React-like syntax and package.json-aware helpers.")
+      .command('init [path]')
+      .description('Creates a README.jsx file template in the specified path')
+      .action(this.CreateReadmeJsx)
+    try {
+      await this.commander.parse(process.argv)
+    }
+    catch {
+      return false;
+    }
+    return true;
+  }
+  /**
+   *
+   * @param path the actual path for the README.md.tsx file to be output
+   */
+  public CreateReadmeJsx(path: string): void {
+    console.log('\n')
+    console.log('Creating README.md.tsx file in with the following path ' + path);
+    //make sure the path is well written
+    if (path.charAt(path.length - 1) !== '/') {
+      path = path + '/';
+      console.log(path)
+    }
+    // we check if the path given exists
+    if (!fs.existsSync(path)) {
+      console.error('Path does not exist')
+      throw new Error('Path specified does not exist');
+    } else {
+      const template_readme_file = `// We need to tell the JSX transpiler that in this file,
+// instead of React we use the custom createElement and Fragment
+// functions from jsx-readme
+/* @jsx MD */
+/* @jsxFrag Fragment */
+import type { Component } from "..";
+import MD, {
+  BadgesFromPkg,
+  CodecovBadge,
+  DescriptionFromPkg,
+  ExamplesFromPkg,
+  Fragment,
+  GithubWorkflowBadge,
+  HomepageFromPkg,
+  renderToFile,
+  TitleFromPkg,
+  DiscordBadge,
+  HacktoberfestBadge,
+  } from "..";
+import { Heading, InlineCode, LineBreak } from "jsx-md";
+import pkg from "./package.json";
+
+const Readme: Component = () => (
+  <Fragment>
+    {/* Create a header with title, badges and description inferred from package.json */}
+    <TitleFromPkg pkg={pkg} />
+    <BadgesFromPkg pkg={pkg} />
+    {/* Add additional badges. */}
+    <CodecovBadge pkg={pkg} />
+    <GithubWorkflowBadge pkg={pkg} workflowName="Build and deploy" />
+    <DiscordBadge
+      inviteLink="https://discord.com/invite/X9HRSK5"
+      serverId="750063320614174871"
+    />
+    <HacktoberfestBadge
+      pkg={pkg}
+      year={2020}
+      suggestionLabel="good first issue"
+    />
+    <LineBreak />
+    <DescriptionFromPkg pkg={pkg} />
+    {/* You can use the components from jsx-md to build custom markdown. */}
+    <Heading level={2}>Installation</Heading>
+    Add <InlineCode>jsx-readme</InlineCode> to your{" "}
+    <InlineCode>devDependencies</InlineCode> and install it. I recommend using
+    it with <InlineCode>ts-node</InlineCode>. Then all you need to do is run {" "} <InlineCode>npx jsx-readme init [destinationPath]</InlineCode>
+    where the {" "} <InlineCode>[destinationPath]</InlineCode> is where the {" "} <InlineCode>README.md.tsx</InlineCode> file will be outputed and once done
+    you run the {" "} <InlineCode>README.md.tsx</InlineCode> via{" "}
+    <InlineCode>ts-node</InlineCode> whenever you want to create a new version
+    of the <InlineCode>README</InlineCode>.
+    <LineBreak />
+    <LineBreak />
+    {/* Create an example section based on all files from the example directory set up in package.json */}
+    <ExamplesFromPkg pkg={pkg} />
+    {/* Create a section linking to the homepage from package.json */}
+    <HomepageFromPkg pkg={pkg} />
+  </Fragment>
+);
+
+void renderToFile("./README.md", <Readme />);
+    `
+      try {
+        fs.writeFileSync(path + 'README.md.tsx', template_readme_file)
+        console.log('README.md.tsx file was created successfully at ' + path)
+      } catch (err: any) {
+        if (err) {
+          console.error("jsx-readme couldn't create template file due to the next error:" + ' ' + err.message)
+          throw new Error("jsx-readme couldn't create template file due to the next error:" + ' ' + err.message)
+        }
+      }
+    }
+  }
+}
+/* eslint-enable @typescript-eslint/no-unsafe-member-access */
+/* eslint-enable @typescript-eslint/no-unsafe-assignment */
+const cli = new Cli();
+
+cli.Start();
+
+process.exit(0);

--- a/test/README.expected.md
+++ b/test/README.expected.md
@@ -19,7 +19,7 @@ Generate Readme files with a React\-like syntax and package\.json\-aware helpers
 
 ## Installation
 
-Add `jsx-readme` to your `devDependencies` and install it. I recommend using it with `ts-node`. Then all you need to do is add a file like in the example below and run it via `ts-node` whenever you want to create a new version of the `README`.
+Add `jsx-readme` to your `devDependencies` and install it. I recommend using it with `ts-node`. Then all you need to do is run `npx jsx-readme init [destinationPath]` where the `[destinationPath]` is where the `README.md.tsx` file will be outputted and once done you run the `README.md.tsx` via `ts-node` whenever you want to create a new version of the `README`.
 
 ## Examples
 

--- a/test/README.expected.tsx
+++ b/test/README.expected.tsx
@@ -16,7 +16,6 @@ import MD, {
   TitleFromPkg,
   DiscordBadge,
   HacktoberfestBadge,
-  LicenseBadge,
 } from "..";
 import { Heading, InlineCode, LineBreak } from "jsx-md";
 import pkg from "./package.json";
@@ -27,7 +26,6 @@ const Readme: Component = () => (
     <TitleFromPkg pkg={pkg} />
     <BadgesFromPkg pkg={pkg} />
     {/* Add additional badges. */}
-    <LicenseBadge pkg={pkg} />
     <CodecovBadge pkg={pkg} />
     <GithubWorkflowBadge pkg={pkg} workflowName="Build and deploy" />
     <DiscordBadge

--- a/test/cli.test.tsx
+++ b/test/cli.test.tsx
@@ -1,0 +1,17 @@
+import * as fs from "fs";
+import { runCli } from "./utils/runCli";
+
+describe("cli README creation script", () => {
+  it("creates the README.md.tsx file of the repo", async () => {
+    const scriptPath = "./src/cli.ts";
+    await runCli(scriptPath);
+
+    const expectedFile = fs.readFileSync("./test/README.expected.tsx", {
+      encoding: "utf8",
+    });
+    const actualFile = fs.readFileSync("./README.md.tsx", {
+      encoding: "utf8",
+    });
+    expect(actualFile).toBe(expectedFile);
+  }, 20000);
+});

--- a/test/utils/runCli.ts
+++ b/test/utils/runCli.ts
@@ -1,0 +1,14 @@
+import child_process from "child_process";
+
+export async function runCli(scriptPath: string): Promise<void> {
+  const childProcess = child_process.exec(`ts-node ${scriptPath} init ./test/`);
+  await new Promise((resolve, reject) => {
+    childProcess.on("exit", (code) => {
+      const SUCCESSFUL_EXIT_CODE = 0;
+      if (code !== SUCCESSFUL_EXIT_CODE) {
+        return reject("Fork failed");
+      }
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
 Creation of small CLI with only one command  with the handle `jsx-readme ` that creates a README.md.tsx file in the specified path, the Docs have been updated adding this new installation process as well as the tests files. you can always test the cli with the e2e test `cli.test.tsx` or run the script `npm run test-cli` and manually check the file created.  <!-- Please only open PRs for issues in place. If there is no issue, please open the issue first. Then create this PR and link it to the issue by adding the issue number in the line below. -->
Closes #6 <!-- Replace this comment with the issue number -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

<!-- If you wrote meaningful commit messages, this is it. If you don't feel confident that your commit messages fully explain your changes and your reasoning behind it, then you can add more information to this PR. Or, even better, update your commit messages ;) -->




DISCLAIMER:
       Now this is a proper pull request without clutter and problems. Sorry for the last one.