### PR TITLE
Add LicenseFromPkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ import MD, {
   DiscordBadge,
   HacktoberfestBadge,
   LicenseBadge,
+  LicenseFromPkg,
 } from "jsx-readme";
 import { Heading, InlineCode, LineBreak } from "jsx-md";
 import pkg from "./package.json";
@@ -156,6 +157,8 @@ const Readme: Component = () => (
     <HomepageFromPkg pkg={pkg} />
     {/* Create a section linking to the contributing guidelines file */}
     <ContributingSection />
+    {/* Create a section linking to the license file. */}
+    <LicenseFromPkg pkg={pkg} />
   </Fragment>
 );
 
@@ -169,4 +172,8 @@ You can find more about this on [https://dbartholomae.github.io/jsx-readme](http
 ## Contributing
 
 If you are interested in contributing to this repository, please read up on the details in our [contributing guidelines](./CONTRIBUTING.md).
+
+## License
+
+MIT. See [LICENSE file](./LICENSE) for details.
 

--- a/examples/README.md.tsx
+++ b/examples/README.md.tsx
@@ -18,6 +18,7 @@ import MD, {
   DiscordBadge,
   HacktoberfestBadge,
   LicenseBadge,
+  LicenseFromPkg,
 } from "..";
 import { Heading, InlineCode, LineBreak } from "jsx-md";
 import pkg from "./package.json";
@@ -58,6 +59,8 @@ const Readme: Component = () => (
     <HomepageFromPkg pkg={pkg} />
     {/* Create a section linking to the contributing guidelines file */}
     <ContributingSection />
+    {/* Create a section linking to the license file. */}
+    <LicenseFromPkg pkg={pkg} />
   </Fragment>
 );
 

--- a/src/PackageJSON.ts
+++ b/src/PackageJSON.ts
@@ -9,6 +9,7 @@ export interface PackageJSON {
     example?: string;
   };
   homepage?: string;
+  license?: string;
   name: string;
   private?: boolean;
   repository?: string | Repository;

--- a/src/components/LicenseFromPkg.test.tsx
+++ b/src/components/LicenseFromPkg.test.tsx
@@ -1,0 +1,42 @@
+/* @jsx Md */
+import Md, { render } from "jsx-md";
+import { LicenseFromPkg } from "./LicenseFromPkg";
+
+describe("LicenseFromPkg", () => {
+  it("renders nothing if there is no license", () => {
+    const pkg = {
+      name: "test-package",
+    };
+    expect(render(<LicenseFromPkg pkg={pkg} />)).toBe("");
+  });
+
+  it("renders a 'License' heading", () => {
+    const pkg = {
+      name: "test-package",
+      license: "MIT",
+    };
+    expect(render(<LicenseFromPkg pkg={pkg} />)).toContain("## License\n");
+  });
+
+  it("renders sentence with a link to the license", () => {
+    const pkg = {
+      name: "test-package",
+      license: "MIT",
+    };
+
+    expect(render(<LicenseFromPkg pkg={pkg} />)).toContain(
+      "MIT. See [LICENSE file](./LICENSE) for details.\n"
+    );
+  });
+
+  it("renders sentence with a custom link to the license", () => {
+    const pkg = {
+      name: "test-package",
+      license: "MIT",
+    };
+
+    expect(
+      render(<LicenseFromPkg pkg={pkg} licenseFilePath="./LICENSE.txt" />)
+    ).toContain("MIT. See [LICENSE file](./LICENSE.txt) for details.\n");
+  });
+});

--- a/src/components/LicenseFromPkg.tsx
+++ b/src/components/LicenseFromPkg.tsx
@@ -1,0 +1,29 @@
+/* @jsx Md */
+import type { Component } from "jsx-md";
+import Md, { Fragment, Heading, LineBreak, Link } from "jsx-md";
+import type { PackageJSON } from "../PackageJSON";
+
+/** @internal */
+interface Props {
+  licenseFilePath?: string;
+  pkg: Readonly<PackageJSON>;
+}
+
+/** Display a section indicating the license defined in package.json */
+export const LicenseFromPkg: Component<Readonly<Props>> = ({
+  pkg: { license },
+  licenseFilePath = "./LICENSE",
+}) => {
+  if (license === undefined) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      <Heading level={2}>License</Heading>
+      {license}. See <Link to={licenseFilePath}>LICENSE file</Link> for details.
+      <LineBreak />
+      <LineBreak />
+    </Fragment>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,5 +10,6 @@ export { BadgesFromPkg } from "./BadgesFromPkg";
 export { ContributingSection } from "./ContributingSection";
 export { ExamplesFromPkg } from "./ExamplesFromPkg";
 export { HomepageFromPkg } from "./HomepageFromPkg";
+export { LicenseFromPkg } from "./LicenseFromPkg";
 export { TitleFromPkg } from "./TitleFromPkg";
 export { DescriptionFromPkg } from "./DescriptionFromPkg";

--- a/test/README.expected.md
+++ b/test/README.expected.md
@@ -116,6 +116,7 @@ import MD, {
   DiscordBadge,
   HacktoberfestBadge,
   LicenseBadge,
+  LicenseFromPkg,
 } from "jsx-readme";
 import { Heading, InlineCode, LineBreak } from "jsx-md";
 import pkg from "./package.json";
@@ -156,6 +157,8 @@ const Readme: Component = () => (
     <HomepageFromPkg pkg={pkg} />
     {/* Create a section linking to the contributing guidelines file */}
     <ContributingSection />
+    {/* Create a section linking to the license file. */}
+    <LicenseFromPkg pkg={pkg} />
   </Fragment>
 );
 
@@ -169,4 +172,8 @@ You can find more about this on [https://dbartholomae.github.io/jsx-readme](http
 ## Contributing
 
 If you are interested in contributing to this repository, please read up on the details in our [contributing guidelines](./CONTRIBUTING.md).
+
+## License
+
+MIT. See [LICENSE file](./LICENSE) for details.
 


### PR DESCRIPTION
Closes #37 

## Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.

---

This PR is made simultaneously with #36. If #36 is merged, will have to update README and the expected README otherwise the test will fail.

As a side note, the reason I name the optional prop `licenseFilePath` instead of `licenseFileName` is because I think file path actually make more sense. For your information, `LicenseBadge` is using `licenseFileName` prop instead of `licenseFilePath`.